### PR TITLE
.github/workflows: use apidiff

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,3 +35,23 @@ jobs:
         run: go test ${{matrix.testflags}} ./...
         env:
           GOARCH: ${{ matrix.goarch }}
+  apidiff:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Restore cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod/cache
+          key: ${{ github.job }}-${{ runner.os }}-${{ matrix.goarch }}-${{ matrix.testflags }}-go-${{ hashFiles('**/go.sum') }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ github.job }}-${{ runner.os }}-${{ matrix.goarch }}-${{ matrix.testflags }}-go-${{ hashFiles('**/go.sum') }}
+            ${{ github.job }}-${{ runner.os }}-${{ matrix.goarch }}-${{ matrix.testflags }}-go-
+      - name: Run api-diff
+        uses: joelanford/go-apidiff@main


### PR DESCRIPTION
This pull request adds a CI job that runs Go's apidiff tool against the last commit in main. It causes the job to fail if a backward-incompatible change is detected in the API.

Fixes #3.