### PR TITLE
mockutil: add Recent matcher

### DIFF
--- a/mockutil/eq.go
+++ b/mockutil/eq.go
@@ -14,7 +14,7 @@ type eqMatcher struct {
 	opts []cmp.Option
 }
 
-// Eq is simiar to gomock.Eq but uses go-cmp, accepts options and returns a
+// Eq is similar to gomock.Eq but uses go-cmp, accepts options and returns a
 // human-readable report of the differences between the compared values.
 func Eq(want interface{}, opts ...cmp.Option) eqMatcher {
 	return eqMatcher{
@@ -41,4 +41,16 @@ func (eq eqMatcher) String() string {
 // another. It uses [cmpopts.EquateApproxtime].
 func EquateNearlySameTime() cmp.Option {
 	return cmpopts.EquateApproxTime(time.Second)
+}
+
+// Recent returns a matcher that evaluates to true if the parameter passed to
+// the mock function is a [time.Time] representing a clock reading from within
+// the last second.
+func Recent() eqMatcher {
+	return eqMatcher{
+		want: time.Now(),
+		opts: []cmp.Option{
+			EquateNearlySameTime(),
+		},
+	}
 }

--- a/mockutil/eq_test.go
+++ b/mockutil/eq_test.go
@@ -88,3 +88,17 @@ func TestEq(t *testing.T) {
 		assert.Equal(t, m.Matches(got), false)
 	})
 }
+
+func TestRecent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Matches time within second", func(t *testing.T) {
+		m := mockutil.Recent()
+		assert.Equal(t, m.Matches(time.Now()), true)
+	})
+
+	t.Run("Reports non-recent time", func(t *testing.T) {
+		m := mockutil.Recent()
+		assert.Equal(t, m.Matches(time.Now().Add(time.Hour)), false)
+	})
+}


### PR DESCRIPTION
An alternative to:

    mockutil.Eq(time.Now(), mockutil.EquateNearlySameTime())

Looks like this:

    mockutil.Recent()