### PR TITLE
temporal: add more helpers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
     branches:
       - "*"
-
 jobs:
   test:
     strategy:
@@ -21,6 +20,10 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: stable
       - name: Restore cache
         uses: actions/cache@v3
         with:
@@ -36,13 +39,18 @@ jobs:
         env:
           GOARCH: ${{ matrix.goarch }}
   apidiff:
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-22.04
+    if: (github.event.action && 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'breaking-change'))
+
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: stable
       - name: Restore cache
         uses: actions/cache@v3
         with:
@@ -55,3 +63,21 @@ jobs:
             ${{ github.job }}-${{ runner.os }}-${{ matrix.goarch }}-${{ matrix.testflags }}-go-
       - name: Run api-diff
         uses: joelanford/go-apidiff@main
+  lint:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          cache: false
+          go-version: stable
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          install-mode: "binary"
+          args: --timeout=10m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,34 @@
+run:
+  deadline: 60s
+
+linters:
+  enable:
+    - misspell
+    - gofumpt
+    - importas
+    - gci
+
+issues:
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - errcheck
+
+linters-settings:
+  gci:
+    no-inline-comments: true
+    no-prefix-comments: false
+    sections:
+      - standard
+      - default
+      - prefix(go.artefactual.dev/tools)
+    section-separators:
+      - newLine
+  importas:
+    no-unaliased: true
+    no-extra-aliases: false
+    alias:
+      - pkg: go.temporal.io/sdk/(\w+)
+        alias: temporalsdk_$1
+      - pkg: go.temporal.io/api/(\w+)
+        alias: temporalapi_$1

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,12 @@
 module go.artefactual.dev/tools
 
-go 1.20
+go 1.21.1
 
 require (
 	github.com/go-logr/logr v1.2.4
 	github.com/go-logr/zapr v1.2.4
 	github.com/google/go-cmp v0.5.9
+	go.temporal.io/api v1.21.0
 	go.temporal.io/sdk v1.24.0
 	go.uber.org/mock v0.3.0
 	go.uber.org/zap v1.24.0
@@ -28,7 +29,6 @@ require (
 	github.com/robfig/cron v1.2.0 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/stretchr/testify v1.8.3 // indirect
-	go.temporal.io/api v1.21.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/net v0.10.0 // indirect

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -7,9 +7,10 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"go.artefactual.dev/tools/log"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
+
+	"go.artefactual.dev/tools/log"
 )
 
 // Custom cmp.Option to ignore the timestamp entry in log records.
@@ -28,7 +29,7 @@ func TestNew(t *testing.T) {
 
 		assertInfoRecord(t, b, map[string]interface{}{
 			"level":  "0",
-			"caller": "log/log_test.go:27",
+			"caller": "log/log_test.go:28",
 			"msg":    "Hello world!",
 			"foo":    "bar",
 		})
@@ -46,7 +47,7 @@ func TestNew(t *testing.T) {
 		assertInfoRecord(t, b, map[string]interface{}{
 			"logger": "name",
 			"level":  "4",
-			"caller": "log/log_test.go:44",
+			"caller": "log/log_test.go:45",
 			"msg":    "Hello world!",
 			"foo":    "bar",
 		})
@@ -60,7 +61,7 @@ func TestNew(t *testing.T) {
 
 		assertErrorRecordWithStacktrace(t, b, map[string]interface{}{
 			"level":  "2",
-			"caller": "log/log_test.go:59",
+			"caller": "log/log_test.go:60",
 			"error":  "EOF",
 			"msg":    "End of file.",
 			"foo":    "bar",
@@ -75,7 +76,7 @@ func TestNew(t *testing.T) {
 
 		assertErrorRecordWithoutStacktrace(t, b, map[string]interface{}{
 			"level":  "2",
-			"caller": "log/log_test.go:74",
+			"caller": "log/log_test.go:75",
 			"error":  "EOF",
 			"msg":    "End of file.",
 			"foo":    "bar",

--- a/temporal/errors.go
+++ b/temporal/errors.go
@@ -1,0 +1,19 @@
+package temporal
+
+import (
+	"errors"
+
+	temporalsdk_temporal "go.temporal.io/sdk/temporal"
+)
+
+func NewNonRetryableError(err error) error {
+	return temporalsdk_temporal.NewNonRetryableApplicationError(err.Error(), "", nil, nil)
+}
+
+func NonRetryableError(err error) bool {
+	applicationError := &temporalsdk_temporal.ApplicationError{}
+	if !errors.As(err, &applicationError) {
+		return false
+	}
+	return applicationError.NonRetryable()
+}

--- a/temporal/heartbeat.go
+++ b/temporal/heartbeat.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"go.temporal.io/sdk/activity"
+	temporalsdk_activity "go.temporal.io/sdk/activity"
 )
 
 type AutoHeartbeat struct {
@@ -18,7 +18,7 @@ type AutoHeartbeat struct {
 // Temporal is planning to provide auto-heartbeating capabilities in the future,
 // see https://github.com/temporalio/features/issues/229 for more.
 func StartAutoHeartbeat(ctx context.Context) *AutoHeartbeat {
-	heartbeatTimeout := activity.GetInfo(ctx).HeartbeatTimeout
+	heartbeatTimeout := temporalsdk_activity.GetInfo(ctx).HeartbeatTimeout
 	if heartbeatTimeout == 0 {
 		return nil
 	}
@@ -31,7 +31,7 @@ func StartAutoHeartbeat(ctx context.Context) *AutoHeartbeat {
 		for {
 			select {
 			case <-ticker.C:
-				activity.RecordHeartbeat(ctx)
+				temporalsdk_activity.RecordHeartbeat(ctx)
 			case <-done:
 				return
 			}

--- a/temporal/heartbeat_test.go
+++ b/temporal/heartbeat_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 	"time"
 
-	"go.temporal.io/sdk/activity"
-	"go.temporal.io/sdk/converter"
-	"go.temporal.io/sdk/testsuite"
-	"go.temporal.io/sdk/workflow"
+	temporalsdk_activity "go.temporal.io/sdk/activity"
+	temporalsdk_converter "go.temporal.io/sdk/converter"
+	temporalsdk_testsuite "go.temporal.io/sdk/testsuite"
+	temporalsdk_workflow "go.temporal.io/sdk/workflow"
 	"gotest.tools/v3/assert"
 
 	"go.artefactual.dev/tools/temporal"
@@ -20,7 +20,7 @@ func TestAutoHeartbeat(t *testing.T) {
 	// Heartbeat listener.
 	received := make(chan struct{}, 10)
 	var calls []string
-	l := func(info *activity.Info, details converter.EncodedValues) {
+	l := func(info *temporalsdk_activity.Info, details temporalsdk_converter.EncodedValues) {
 		calls = append(calls, info.ActivityID)
 		received <- struct{}{}
 	}
@@ -38,15 +38,15 @@ func TestAutoHeartbeat(t *testing.T) {
 		return nil
 	}
 
-	w := func(ctx workflow.Context) error {
-		ctx = workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+	w := func(ctx temporalsdk_workflow.Context) error {
+		ctx = temporalsdk_workflow.WithActivityOptions(ctx, temporalsdk_workflow.ActivityOptions{
 			StartToCloseTimeout: time.Second,
 			HeartbeatTimeout:    time.Millisecond,
 		})
-		return workflow.ExecuteActivity(ctx, a).Get(ctx, nil)
+		return temporalsdk_workflow.ExecuteActivity(ctx, a).Get(ctx, nil)
 	}
 
-	ts := &testsuite.WorkflowTestSuite{}
+	ts := &temporalsdk_testsuite.WorkflowTestSuite{}
 	env := ts.NewTestWorkflowEnvironment()
 	env.RegisterWorkflow(w)
 	env.RegisterActivity(a)

--- a/temporal/history.go
+++ b/temporal/history.go
@@ -1,0 +1,47 @@
+package temporal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	temporalapi_common "go.temporal.io/api/common/v1"
+	temporalapi_enums "go.temporal.io/api/enums/v1"
+	temporalapi_history "go.temporal.io/api/history/v1"
+	temporalsdk_client "go.temporal.io/sdk/client"
+)
+
+func HistoryEvents(ctx context.Context, cc temporalsdk_client.Client, exec *temporalapi_common.WorkflowExecution, poll bool) ([]*temporalapi_history.HistoryEvent, error) {
+	iter := cc.GetWorkflowHistory(ctx, exec.GetWorkflowId(), exec.GetRunId(), poll, temporalapi_enums.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
+	var events []*temporalapi_history.HistoryEvent
+	for iter.HasNext() {
+		event, err := iter.Next()
+		if err != nil {
+			return nil, fmt.Errorf("error looking up history events: %w", err)
+		}
+
+		events = append(events, event)
+	}
+
+	if len(events) == 0 {
+		return nil, errors.New("error looking up history events: history is empty")
+	}
+
+	return events, nil
+}
+
+func FirstHistoryEvent(ctx context.Context, cc temporalsdk_client.Client, exec *temporalapi_common.WorkflowExecution) (event *temporalapi_history.HistoryEvent, err error) {
+	const polling = false
+	iter := cc.GetWorkflowHistory(ctx, exec.GetWorkflowId(), exec.GetRunId(), polling, temporalapi_enums.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT)
+
+	for iter.HasNext() {
+		event, err = iter.Next()
+		if err != nil {
+			return nil, fmt.Errorf("error looking up history events: %w", err)
+		} else {
+			break
+		}
+	}
+
+	return event, nil
+}

--- a/temporal/temporal.go
+++ b/temporal/temporal.go
@@ -1,9 +1,0 @@
-package temporal
-
-import (
-	"go.temporal.io/sdk/temporal"
-)
-
-func NonRetryableError(err error) error {
-	return temporal.NewNonRetryableApplicationError(err.Error(), "", nil, nil)
-}


### PR DESCRIPTION
Incompatible changes:

- `go.artefactual.dev/tools/temporal`: `NonRetryableError` now returns a boolean, use `NewNonRetryableError` to build a new non-retryable error.