### PR TITLE
Add max heartbeat interval

### DIFF
--- a/temporal/heartbeat.go
+++ b/temporal/heartbeat.go
@@ -23,8 +23,14 @@ func StartAutoHeartbeat(ctx context.Context) *AutoHeartbeat {
 		return nil
 	}
 
-	// We'll heartbeat twice as often as timeout (this is throttled anyways).
-	ticker := time.NewTicker(heartbeatTimeout / 2)
+	// We want to heartbeat three times as often as timeout (this is throttled anyways).
+	heartbeatInterval := heartbeatTimeout / 3
+	// We don't want to heartbeat in intervals higher than 10 seconds.
+	maxHeartBeatInterval := time.Second * 10
+	if heartbeatInterval > maxHeartBeatInterval {
+		heartbeatInterval = maxHeartBeatInterval
+	}
+	ticker := time.NewTicker(heartbeatInterval)
 	done := make(chan struct{})
 	go func() {
 		defer ticker.Stop()


### PR DESCRIPTION
This PR aims to add a Max heartbeat interval to the auto heartbeat function. Some activities could have long heartbeat timeout periods, so we want to keep the intervals no longer than 10 seconds regardless of the timeout. I the amount of heartbeats was increased from 2 to 3 (per timeout period).