### PR TITLE
Add DerefWithDefault to ref package

### DIFF
--- a/ref/ref.go
+++ b/ref/ref.go
@@ -34,6 +34,15 @@ func DerefZero[T any](x *T) T {
 	return *x
 }
 
+// DerefDefault returns the value stored at the pointer x.
+// It returns the provided default when the pointer is nil.
+func DerefDefault[T any](x *T, d T) T {
+	if x == nil {
+		return d
+	}
+	return *x
+}
+
 // UnsignedPtr converts a signed integer into an unsigned integer.
 func UnsignedPtr[S constraints.Signed, U constraints.Unsigned](s *S) *U {
 	var ret *U

--- a/ref/ref_test.go
+++ b/ref/ref_test.go
@@ -39,12 +39,16 @@ func TestDeref(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Returns the value referenced by the pointer", func(t *testing.T) {
+		t.Parallel()
+
 		s := "string"
 
 		assert.Equal(t, s, ref.Deref(&s))
 	})
 
 	t.Run("Panics if a nil value is received", func(t *testing.T) {
+		t.Parallel()
+
 		defer func() {
 			if r := recover(); r == nil {
 				t.Errorf("ref.Deref did not panic.")
@@ -58,12 +62,33 @@ func TestDerefZero(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Returns the underlying value of the pointer", func(t *testing.T) {
+		t.Parallel()
+
 		s := "string"
 		assert.Equal(t, ref.DerefZero(&s), "string")
 	})
 
-	t.Run("Returns the default value if the pointer is nil", func(t *testing.T) {
+	t.Run("Returns the zero value if the pointer is nil", func(t *testing.T) {
+		t.Parallel()
+
 		assert.Equal(t, ref.DerefZero[string](nil), "")
+	})
+}
+
+func TestDerefDefault(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Returns the underlying value of the pointer", func(t *testing.T) {
+		t.Parallel()
+
+		s := "string"
+		assert.Equal(t, ref.DerefDefault(&s, "default"), "string")
+	})
+
+	t.Run("Returns the default value if the pointer is nil", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Equal(t, ref.DerefDefault[string](nil, "default"), "default")
 	})
 }
 


### PR DESCRIPTION
This PR adds `func DerefDefault[T any](x *T, d T) T` which is just like `ref.DerefZero` but it returns the default value specified by `d`, instead of the zero value, when the pointer `x` is nil, e.g.:

```go
x := (*string)(nil)
fmt.Println(ref.DerefDefault(x, "default")) // "default"

y := "data"
fmt.Println(ref.DerefDefault(&y, "default")) // "data"
```