### PR TITLE
Log from activity interceptor

### DIFF
--- a/temporal/log.go
+++ b/temporal/log.go
@@ -74,6 +74,9 @@ var loggerContextKey = contextKey{}
 
 func (a *activityInboundInterceptor) ExecuteActivity(ctx context.Context, in *temporalsdk_interceptor.ExecuteActivityInput) (interface{}, error) {
 	ctx = context.WithValue(ctx, loggerContextKey, a.logger)
+
+	a.logger.V(1).Info("Executing activity.")
+
 	return a.Next.ExecuteActivity(ctx, in)
 }
 


### PR DESCRIPTION
In response to https://github.com/artefactual-sdps/enduro/pull/1015#discussion_r1743122378. This approach makes sure that we always log the worker activity execution event regardless whether the activity implementor did any logging, and this is true even for internal activities like `internalSessionCreationActivity` that the application developer doesn't own.

This:

    [enduro-a3m-worker] 2024-09-04T08:41:22.920Z	V(1)	enduro-a3m-worker	activities/download.go:44	Executing DownloadActivity	{"ActivityID": "14", "ActivityType": "download-activity", "Key": "small.zip", "WatcherName": "dev-minio"}

Becomes:

    [enduro-a3m-worker] 2024-09-04T08:41:22.920Z	V(1)	enduro-a3m-worker	temporal/log.go:84	Executing activity.	{"ActivityID": "14", "ActivityType": "download-activity"}

The main difference is that we can't include the file name or line number (from the goroutine stack) because that information is only available to the callee - not sure if that's enough to reject this idea. This is also the case in the traces that we're emitting with the trace interceptor.