### PR TITLE
Add Azure blob storage support to bucket

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml

--- a/.idea/golinter.xml
+++ b/.idea/golinter.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="GoLinterSettings">
-    <option name="customConfigFile" value="$PROJECT_DIR$/.golangci.yml" />
-    <option name="useCustomConfigFile" value="true" />
-  </component>
-</project>

--- a/.idea/gotools.iml
+++ b/.idea/gotools.iml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
-  <component name="Go" enabled="true" />
-  <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/gotools.iml" filepath="$PROJECT_DIR$/.idea/gotools.iml" />
-    </modules>
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="" vcs="Git" />
-  </component>
-</project>


### PR DESCRIPTION
In order to support Azure blob storage via URL the import needs to be added: `_ "gocloud.dev/blob/azureblob"` in order to "loaded" in the go.mod and also to be loaded as an available blob scheme.

With the current version this is the error that appears: 
```json
{"error": "open bucket from URL \"azblob://sips\": open blob.Bucket: no driver registered for \"azblob\" for URL \"azblob://sips\"; available schemes: file, s3, sftp"}
```
With the change in the PR `azblob` will become one of the available schemes.

This is part of the development for: https://github.com/artefactual-sdps/enduro/issues/1231