### PR TITLE
Add clientauth package

### DIFF
--- a/clientauth/doc.go
+++ b/clientauth/doc.go
@@ -1,0 +1,3 @@
+// Package clientauth provides OAuth2/OIDC client-credentials authentication
+// for outbound HTTP requests.
+package clientauth

--- a/clientauth/provider.go
+++ b/clientauth/provider.go
@@ -1,0 +1,251 @@
+package clientauth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+const (
+	defaultTokenExpiryLeeway       = 30 * time.Second
+	defaultRetryMaxAttempts        = 3
+	defaultRetryInitialInterval    = 500 * time.Millisecond
+	defaultRetryMaxInterval        = 2 * time.Second
+	defaultRetryBackoffCoefficient = 2.0
+)
+
+// AccessTokenProvider returns access tokens for outbound authenticated
+// requests.
+type AccessTokenProvider interface {
+	// AccessToken returns a bearer token suitable for an Authorization header.
+	AccessToken(ctx context.Context) (string, error)
+}
+
+// OIDCAccessTokenProviderConfig configures an [OIDCAccessTokenProvider] that
+// uses the OAuth2 client credentials flow.
+type OIDCAccessTokenProviderConfig struct {
+	// ProviderURL is the OIDC issuer URL for endpoint discovery.
+	// Ignored when TokenURL is set.
+	ProviderURL string
+	// TokenURL is the token endpoint. Discovered from ProviderURL if empty.
+	TokenURL     string
+	ClientID     string
+	ClientSecret string
+	Scopes       []string // Optional token scopes.
+	Audience     string   // Optional audience endpoint parameter.
+	// TokenExpiryLeeway is a safety window to refresh tokens before expiry.
+	TokenExpiryLeeway       time.Duration
+	RetryMaxAttempts        int           // Total token endpoint attempts.
+	RetryInitialInterval    time.Duration // Initial retry backoff.
+	RetryMaxInterval        time.Duration // Upper bound for retry backoff.
+	RetryBackoffCoefficient float64       // Exponential backoff multiplier.
+}
+
+// setDefaults fills zero-valued fields with defaults.
+func (c *OIDCAccessTokenProviderConfig) setDefaults() {
+	if c.TokenExpiryLeeway == 0 {
+		c.TokenExpiryLeeway = defaultTokenExpiryLeeway
+	}
+	if c.RetryMaxAttempts == 0 {
+		c.RetryMaxAttempts = defaultRetryMaxAttempts
+	}
+	if c.RetryInitialInterval == 0 {
+		c.RetryInitialInterval = defaultRetryInitialInterval
+	}
+	if c.RetryMaxInterval == 0 {
+		c.RetryMaxInterval = defaultRetryMaxInterval
+	}
+	if c.RetryBackoffCoefficient == 0 {
+		c.RetryBackoffCoefficient = defaultRetryBackoffCoefficient
+	}
+}
+
+// Validate fills zero-valued fields with defaults and validates the config.
+func (c *OIDCAccessTokenProviderConfig) Validate() error {
+	c.setDefaults()
+
+	var errs []error
+	if c.ProviderURL == "" && c.TokenURL == "" {
+		errs = append(errs, errors.New("missing OIDC providerURL or tokenURL"))
+	}
+	if c.ClientID == "" || c.ClientSecret == "" {
+		errs = append(errs, errors.New("missing OIDC client credentials"))
+	}
+	if c.RetryMaxAttempts < 1 {
+		errs = append(errs, errors.New("invalid OIDC retry max attempts, value must be >= 1"))
+	}
+	if c.RetryInitialInterval <= 0 || c.RetryMaxInterval <= 0 || c.TokenExpiryLeeway <= 0 {
+		errs = append(errs, errors.New("invalid OIDC duration configuration, values must be > 0"))
+	}
+	if c.RetryMaxInterval < c.RetryInitialInterval {
+		errs = append(errs, errors.New(
+			"invalid OIDC retry interval configuration, max interval must be >= initial interval",
+		))
+	}
+	if c.RetryBackoffCoefficient < 1 {
+		errs = append(errs, errors.New("invalid OIDC retry backoff coefficient, value must be >= 1"))
+	}
+
+	return errors.Join(errs...)
+}
+
+// oidcAccessTokenProvider fetches and caches access tokens using the OAuth2
+// client credentials flow.
+type oidcAccessTokenProvider struct {
+	mu                      sync.RWMutex // Guards token reads and refresh.
+	token                   *oauth2.Token
+	cc                      clientcredentials.Config
+	tokenExpiryLeeway       time.Duration
+	retryMaxAttempts        int
+	retryInitialInterval    time.Duration
+	retryMaxInterval        time.Duration
+	retryBackoffCoefficient float64
+}
+
+var _ AccessTokenProvider = (*oidcAccessTokenProvider)(nil)
+
+// NewOIDCAccessTokenProvider builds an [AccessTokenProvider] from OIDC/OAuth2
+// client credentials settings. It calls [OIDCAccessTokenProviderConfig.Validate]
+// before proceeding.
+func NewOIDCAccessTokenProvider(
+	ctx context.Context,
+	cfg OIDCAccessTokenProviderConfig,
+) (AccessTokenProvider, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	tokenURL := cfg.TokenURL
+	if tokenURL == "" {
+		provider, err := oidc.NewProvider(ctx, cfg.ProviderURL)
+		if err != nil {
+			return nil, fmt.Errorf("discover OIDC provider: %w", err)
+		}
+		tokenURL = provider.Endpoint().TokenURL
+	}
+	if tokenURL == "" {
+		return nil, errors.New("missing OIDC token endpoint URL")
+	}
+
+	cc := clientcredentials.Config{
+		ClientID:     cfg.ClientID,
+		ClientSecret: cfg.ClientSecret,
+		TokenURL:     tokenURL,
+		Scopes:       cfg.Scopes,
+	}
+	if cfg.Audience != "" {
+		cc.EndpointParams = url.Values{"audience": []string{cfg.Audience}}
+	}
+
+	return &oidcAccessTokenProvider{
+		cc:                      cc,
+		tokenExpiryLeeway:       cfg.TokenExpiryLeeway,
+		retryMaxAttempts:        cfg.RetryMaxAttempts,
+		retryInitialInterval:    cfg.RetryInitialInterval,
+		retryMaxInterval:        cfg.RetryMaxInterval,
+		retryBackoffCoefficient: cfg.RetryBackoffCoefficient,
+	}, nil
+}
+
+// AccessToken returns a cached token when still valid, or fetches a new one.
+func (p *oidcAccessTokenProvider) AccessToken(ctx context.Context) (string, error) {
+	p.mu.RLock()
+	if !p.tokenNeedsRefresh() {
+		defer p.mu.RUnlock()
+		return p.token.AccessToken, nil
+	}
+	p.mu.RUnlock()
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Re-check: another goroutine may have refreshed while we waited.
+	if !p.tokenNeedsRefresh() {
+		return p.token.AccessToken, nil
+	}
+
+	token, err := p.requestToken(ctx)
+	if err != nil {
+		return "", fmt.Errorf("request OIDC token: %w", err)
+	}
+	p.token = token
+
+	return p.token.AccessToken, nil
+}
+
+// tokenNeedsRefresh reports whether the cached token is missing or near expiry.
+func (p *oidcAccessTokenProvider) tokenNeedsRefresh() bool {
+	if p.token == nil || p.token.AccessToken == "" {
+		return true
+	}
+	if p.token.Expiry.IsZero() {
+		return false
+	}
+
+	return p.token.Expiry.Before(time.Now().Add(p.tokenExpiryLeeway))
+}
+
+// requestToken fetches a token, retrying transient failures with backoff.
+func (p *oidcAccessTokenProvider) requestToken(ctx context.Context) (*oauth2.Token, error) {
+	var err error
+	var token *oauth2.Token
+	ts := p.cc.TokenSource(ctx)
+	for attempt := 1; attempt <= p.retryMaxAttempts; attempt++ {
+		token, err = ts.Token()
+		if err == nil {
+			return token, nil
+		}
+		if !isRetryableErr(err) || attempt == p.retryMaxAttempts {
+			break
+		}
+
+		if wait := p.backoff(attempt); wait > 0 {
+			timer := time.NewTimer(wait)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return nil, ctx.Err()
+			case <-timer.C:
+			}
+		}
+	}
+
+	return nil, err
+}
+
+// backoff returns the retry wait duration for the given attempt.
+func (p *oidcAccessTokenProvider) backoff(attempt int) time.Duration {
+	if p.retryInitialInterval <= 0 {
+		return 0
+	}
+
+	wait := float64(p.retryInitialInterval) * math.Pow(p.retryBackoffCoefficient, float64(attempt-1))
+	if p.retryMaxInterval > 0 {
+		wait = math.Min(wait, float64(p.retryMaxInterval))
+	}
+
+	return time.Duration(wait)
+}
+
+// isRetryableErr reports whether err is worth retrying.
+func isRetryableErr(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	var rerr *oauth2.RetrieveError
+	if errors.As(err, &rerr) && rerr.Response != nil {
+		return rerr.Response.StatusCode >= http.StatusInternalServerError
+	}
+
+	return true
+}

--- a/clientauth/provider_test.go
+++ b/clientauth/provider_test.go
@@ -1,0 +1,312 @@
+package clientauth_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+
+	"go.artefactual.dev/tools/clientauth"
+)
+
+type tokenResponse struct {
+	statusCode  int
+	accessToken string
+	expiresIn   int
+}
+
+// tokenServer returns a test server that replies with each successive response.
+// Callers must supply enough entries to cover all expected token attempts.
+func tokenServer(t *testing.T, responses []tokenResponse) *httptest.Server {
+	t.Helper()
+
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		res := responses[calls-1]
+		if res.statusCode != http.StatusOK {
+			w.WriteHeader(res.statusCode)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		err := json.NewEncoder(w).Encode(map[string]any{
+			"token_type":   "Bearer",
+			"access_token": res.accessToken,
+			"expires_in":   res.expiresIn,
+		})
+		assert.NilError(t, err)
+	}))
+
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+func TestOIDCAccessTokenProviderAccessToken(t *testing.T) {
+	t.Parallel()
+
+	type test struct {
+		name       string
+		responses  []tokenResponse
+		calls      int
+		wantTokens []string
+		wantErr    string
+	}
+
+	for _, tc := range []test{
+		{
+			name: "Caches token without expiry",
+			responses: []tokenResponse{
+				{statusCode: http.StatusOK, accessToken: "token-1"},
+			},
+			calls:      2,
+			wantTokens: []string{"token-1", "token-1"},
+		},
+		{
+			name: "Refreshes token that is within leeway window",
+			responses: []tokenResponse{
+				{statusCode: http.StatusOK, accessToken: "token-1", expiresIn: 1},
+				{statusCode: http.StatusOK, accessToken: "token-2", expiresIn: 3600},
+			},
+			calls:      2,
+			wantTokens: []string{"token-1", "token-2"},
+		},
+		{
+			name: "Retries transient token endpoint failures",
+			responses: []tokenResponse{
+				{statusCode: http.StatusBadGateway},
+				{statusCode: http.StatusBadGateway},
+				{statusCode: http.StatusOK, accessToken: "token-ok", expiresIn: 3600},
+			},
+			calls:      1,
+			wantTokens: []string{"token-ok"},
+		},
+		{
+			name: "Returns error if token endpoint returns non-retryable error",
+			responses: []tokenResponse{
+				{statusCode: http.StatusBadRequest},
+				{statusCode: http.StatusBadRequest},
+			},
+			calls:   1,
+			wantErr: "request OIDC token: oauth2: cannot fetch token: 400 Bad Request",
+		},
+		{
+			name: "Returns error after retry attempts are exhausted",
+			responses: []tokenResponse{
+				{statusCode: http.StatusBadGateway},
+				{statusCode: http.StatusBadGateway},
+				{statusCode: http.StatusBadGateway},
+				{statusCode: http.StatusBadGateway},
+				{statusCode: http.StatusBadGateway},
+				{statusCode: http.StatusBadGateway},
+			},
+			calls:   1,
+			wantErr: "request OIDC token: oauth2: cannot fetch token: 502 Bad Gateway",
+		},
+		{
+			name: "Returns error if token endpoint returns an empty token",
+			responses: []tokenResponse{
+				{statusCode: http.StatusOK, accessToken: ""},
+				{statusCode: http.StatusOK, accessToken: ""},
+				{statusCode: http.StatusOK, accessToken: ""},
+				{statusCode: http.StatusOK, accessToken: ""},
+				{statusCode: http.StatusOK, accessToken: ""},
+				{statusCode: http.StatusOK, accessToken: ""},
+			},
+			calls:   1,
+			wantErr: "request OIDC token: oauth2: server response missing access_token",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := tokenServer(t, tc.responses)
+
+			cfg := clientauth.OIDCAccessTokenProviderConfig{
+				TokenURL:                srv.URL,
+				ClientID:                "client-id",
+				ClientSecret:            "client-secret",
+				RetryMaxAttempts:        3,
+				RetryInitialInterval:    time.Microsecond,
+				RetryMaxInterval:        time.Microsecond,
+				RetryBackoffCoefficient: 1.0,
+				TokenExpiryLeeway:       30 * time.Second,
+			}
+
+			provider, err := clientauth.NewOIDCAccessTokenProvider(t.Context(), cfg)
+			assert.NilError(t, err)
+
+			var tokens []string
+			for range tc.calls {
+				token, err := provider.AccessToken(t.Context())
+				if tc.wantErr != "" {
+					assert.ErrorContains(t, err, tc.wantErr)
+					return
+				}
+
+				assert.NilError(t, err)
+				tokens = append(tokens, token)
+			}
+
+			assert.DeepEqual(t, tokens, tc.wantTokens)
+		})
+	}
+}
+
+func TestOIDCAccessTokenProviderConfigValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cfg     clientauth.OIDCAccessTokenProviderConfig
+		wantCfg clientauth.OIDCAccessTokenProviderConfig
+		wantErr string
+	}{
+		{
+			name: "Passes validation with provider URL and client credentials",
+			cfg: clientauth.OIDCAccessTokenProviderConfig{
+				ProviderURL:  "https://idp.example.com/realms/enduro",
+				ClientID:     "enduro-worker",
+				ClientSecret: "secret",
+			},
+			wantCfg: clientauth.OIDCAccessTokenProviderConfig{
+				ProviderURL:             "https://idp.example.com/realms/enduro",
+				ClientID:                "enduro-worker",
+				ClientSecret:            "secret",
+				TokenExpiryLeeway:       30 * time.Second,
+				RetryMaxAttempts:        3,
+				RetryInitialInterval:    500 * time.Millisecond,
+				RetryMaxInterval:        2 * time.Second,
+				RetryBackoffCoefficient: 2.0,
+			},
+		},
+		{
+			name: "Passes validation with token URL and client credentials",
+			cfg: clientauth.OIDCAccessTokenProviderConfig{
+				TokenURL:     "https://idp.example.com/token",
+				ClientID:     "enduro-worker",
+				ClientSecret: "secret",
+			},
+			wantCfg: clientauth.OIDCAccessTokenProviderConfig{
+				TokenURL:                "https://idp.example.com/token",
+				ClientID:                "enduro-worker",
+				ClientSecret:            "secret",
+				TokenExpiryLeeway:       30 * time.Second,
+				RetryMaxAttempts:        3,
+				RetryInitialInterval:    500 * time.Millisecond,
+				RetryMaxInterval:        2 * time.Second,
+				RetryBackoffCoefficient: 2.0,
+			},
+		},
+		{
+			name: "Preserves explicitly set values",
+			cfg: clientauth.OIDCAccessTokenProviderConfig{
+				ProviderURL:             "https://idp.example.com/realms/enduro",
+				ClientID:                "enduro-worker",
+				ClientSecret:            "secret",
+				TokenExpiryLeeway:       10 * time.Second,
+				RetryMaxAttempts:        5,
+				RetryInitialInterval:    1 * time.Second,
+				RetryMaxInterval:        10 * time.Second,
+				RetryBackoffCoefficient: 3.0,
+			},
+			wantCfg: clientauth.OIDCAccessTokenProviderConfig{
+				ProviderURL:             "https://idp.example.com/realms/enduro",
+				ClientID:                "enduro-worker",
+				ClientSecret:            "secret",
+				TokenExpiryLeeway:       10 * time.Second,
+				RetryMaxAttempts:        5,
+				RetryInitialInterval:    1 * time.Second,
+				RetryMaxInterval:        10 * time.Second,
+				RetryBackoffCoefficient: 3.0,
+			},
+		},
+		{
+			name: "Fails validation when both providerURL and tokenURL are missing",
+			cfg: clientauth.OIDCAccessTokenProviderConfig{
+				ClientID:     "enduro-worker",
+				ClientSecret: "secret",
+			},
+			wantErr: "missing OIDC providerURL or tokenURL",
+		},
+		{
+			name: "Fails validation when client credentials are missing",
+			cfg: clientauth.OIDCAccessTokenProviderConfig{
+				ProviderURL: "https://idp.example.com/realms/enduro",
+			},
+			wantErr: "missing OIDC client credentials",
+		},
+		{
+			name: "Fails validation with invalid retry attempts",
+			cfg: clientauth.OIDCAccessTokenProviderConfig{
+				ProviderURL:      "https://idp.example.com/realms/enduro",
+				ClientID:         "enduro-worker",
+				ClientSecret:     "secret",
+				RetryMaxAttempts: -1,
+			},
+			wantErr: "invalid OIDC retry max attempts, value must be >= 1",
+		},
+		{
+			name: "Fails validation with invalid retry backoff coefficient",
+			cfg: clientauth.OIDCAccessTokenProviderConfig{
+				ProviderURL:             "https://idp.example.com/realms/enduro",
+				ClientID:                "enduro-worker",
+				ClientSecret:            "secret",
+				RetryBackoffCoefficient: 0.5,
+				RetryMaxAttempts:        3,
+				RetryInitialInterval:    1 * time.Millisecond,
+				RetryMaxInterval:        2 * time.Millisecond,
+			},
+			wantErr: "invalid OIDC retry backoff coefficient, value must be >= 1",
+		},
+		{
+			name: "Joins multiple validation errors",
+			cfg: clientauth.OIDCAccessTokenProviderConfig{
+				RetryMaxAttempts:        -1,
+				RetryBackoffCoefficient: 0.5,
+			},
+			wantErr: "missing OIDC providerURL or tokenURL\nmissing OIDC client credentials\ninvalid OIDC retry max attempts, value must be >= 1\ninvalid OIDC retry backoff coefficient, value must be >= 1",
+		},
+		{
+			name: "Fails validation with invalid duration values",
+			cfg: clientauth.OIDCAccessTokenProviderConfig{
+				ProviderURL:          "https://idp.example.com/realms/enduro",
+				ClientID:             "enduro-worker",
+				ClientSecret:         "secret",
+				TokenExpiryLeeway:    -1 * time.Second,
+				RetryInitialInterval: -1 * time.Millisecond,
+			},
+			wantErr: "invalid OIDC duration configuration, values must be > 0",
+		},
+		{
+			name: "Fails validation with max interval lower than initial interval",
+			cfg: clientauth.OIDCAccessTokenProviderConfig{
+				ProviderURL:          "https://idp.example.com/realms/enduro",
+				ClientID:             "enduro-worker",
+				ClientSecret:         "secret",
+				RetryInitialInterval: 2 * time.Millisecond,
+				RetryMaxInterval:     1 * time.Millisecond,
+			},
+			wantErr: "invalid OIDC retry interval configuration, max interval must be >= initial interval",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tc.cfg.Validate()
+			if tc.wantErr != "" {
+				assert.Error(t, err, tc.wantErr)
+				return
+			}
+
+			assert.NilError(t, err)
+			assert.DeepEqual(t, tc.cfg, tc.wantCfg)
+		})
+	}
+}

--- a/clientauth/transport.go
+++ b/clientauth/transport.go
@@ -1,0 +1,35 @@
+package clientauth
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// BearerTransport injects a bearer token into each request's Authorization
+// header before delegating to the wrapped transport.
+type BearerTransport struct {
+	base          http.RoundTripper
+	tokenProvider AccessTokenProvider
+}
+
+// NewBearerTransport returns a transport that adds bearer tokens from provider
+// to each request. If base is nil, [http.DefaultTransport] is used.
+func NewBearerTransport(base http.RoundTripper, provider AccessTokenProvider) *BearerTransport {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return &BearerTransport{base: base, tokenProvider: provider}
+}
+
+// RoundTrip clones req, sets the Authorization header, and forwards it.
+func (t *BearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	token, err := t.tokenProvider.AccessToken(req.Context())
+	if err != nil {
+		return nil, fmt.Errorf("get access token: %w", err)
+	}
+
+	clonedReq := req.Clone(req.Context())
+	clonedReq.Header.Set("Authorization", "Bearer "+token)
+
+	return t.base.RoundTrip(clonedReq)
+}

--- a/clientauth/transport_test.go
+++ b/clientauth/transport_test.go
@@ -1,0 +1,94 @@
+package clientauth_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"go.artefactual.dev/tools/clientauth"
+)
+
+type roundTripper struct {
+	req *http.Request
+	err error
+}
+
+func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.req = req
+	if rt.err != nil {
+		return nil, rt.err
+	}
+
+	return &http.Response{}, nil
+}
+
+type tokenProvider struct {
+	token string
+	err   error
+}
+
+func (p *tokenProvider) AccessToken(context.Context) (string, error) {
+	return p.token, p.err
+}
+
+func TestBearerTransportRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	type test struct {
+		name          string
+		providerToken string
+		providerErr   error
+		baseErr       error
+		want          string
+		wantErr       string
+	}
+
+	for _, tc := range []test{
+		{
+			name:          "Adds authorization header",
+			providerToken: "token-1",
+			want:          "Bearer token-1",
+		},
+		{
+			name:        "Returns token provider errors",
+			providerErr: errors.New("token error"),
+			wantErr:     "get access token: token error",
+		},
+		{
+			name:          "Returns base transport errors",
+			providerToken: "token-3",
+			baseErr:       errors.New("base transport error"),
+			want:          "Bearer token-3",
+			wantErr:       "base transport error",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			base := &roundTripper{err: tc.baseErr}
+			transport := clientauth.NewBearerTransport(base, &tokenProvider{
+				token: tc.providerToken,
+				err:   tc.providerErr,
+			})
+
+			req, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
+			assert.NilError(t, err)
+
+			res, err := transport.RoundTrip(req)
+			if res != nil && res.Body != nil {
+				_ = res.Body.Close()
+			}
+
+			if tc.wantErr != "" {
+				assert.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+
+			assert.NilError(t, err)
+			assert.Equal(t, base.req.Header.Get("Authorization"), tc.want)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,13 @@
 module go.artefactual.dev/tools
 
-go 1.24
+go 1.24.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.36.3
 	github.com/aws/aws-sdk-go-v2/config v1.29.12
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.65
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.78.2
+	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/go-logr/logr v1.4.2
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/go-cmp v0.7.0
@@ -17,6 +18,7 @@ require (
 	go.uber.org/zap v1.27.0
 	gocloud.dev v0.41.0
 	golang.org/x/exp v0.0.0-20231219180239-dc181d75b848
+	golang.org/x/oauth2 v0.35.0
 	gotest.tools/v3 v3.5.2
 )
 
@@ -56,6 +58,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707 // indirect
 	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a // indirect
+	github.com/go-jose/go-jose/v4 v4.1.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
@@ -99,7 +102,6 @@ require (
 	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/mod v0.24.0 // indirect
 	golang.org/x/net v0.38.0 // indirect
-	golang.org/x/oauth2 v0.28.0 // indirect
 	golang.org/x/sync v0.12.0 // indirect
 	golang.org/x/sys v0.31.0 // indirect
 	golang.org/x/text v0.23.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/xds/go v0.0.0-20250326154945-ae57f3c0d45f h1:C5bqEmzEPLsHm9Mv73lSE9e9bKV23aB1vxOsmZrkl3k=
 github.com/cncf/xds/go v0.0.0-20250326154945-ae57f3c0d45f/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
+github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=
+github.com/coreos/go-oidc/v3 v3.17.0/go.mod h1:wqPbKFrVnE90vty060SB40FCJ8fTHTxSwyXJqZH+sI8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -148,6 +150,8 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-jose/go-jose/v4 v4.1.3 h1:CVLmWDhDVRa6Mi/IgCgaopNosCaHz7zrMeF9MlZRkrs=
+github.com/go-jose/go-jose/v4 v4.1.3/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
@@ -465,8 +469,8 @@ golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
-golang.org/x/oauth2 v0.28.0 h1:CrgCKl8PPAVtLnU3c+EDw6x11699EWlsDeWNWKdIOkc=
-golang.org/x/oauth2 v0.28.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT8=
+golang.org/x/oauth2 v0.35.0 h1:Mv2mzuHuZuY2+bkyWXIHMfhNdJAdwW3FuWeCPYN5GVQ=
+golang.org/x/oauth2 v0.35.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
Add a reusable clientauth package for outbound HTTP authentication using OAuth2 client credentials with OIDC discovery. Implement an access token provider that caches tokens, refreshes them before expiry, and retries transient token endpoint failures with configurable exponential backoff. Implement a bearer RoundTripper that injects `Authorization: Bearer` headers into outgoing requests. Add provider configuration defaults and validation.

Moved from Enduro to be able to reuse it in other projects. Most documentation comments are AI generated, and I have my conflicts about moving the defaults and config validation here; let me know your thoughts.