### PR TITLE
Update go requirements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 1
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version: ${{ matrix.gover }}
       - name: Test all
@@ -29,7 +29,7 @@ jobs:
         env:
           GOARCH: ${{ matrix.goarch }}
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
   apidiff:
@@ -37,39 +37,39 @@ jobs:
     if: (github.event.action && 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'breaking-change'))
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
       - name: Run api-diff
-        uses: joelanford/go-apidiff@main
+        uses: joelanford/go-apidiff@60c4206be8f84348ebda2a3e0c3ac9cb54b8f685 # v0.8.3
   lint:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
   mod:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
       - name: Check go.mod

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,9 @@ jobs:
       # Don't abort the entire matrix if one element fails.
       fail-fast: false
       matrix:
-        gover: ["1.24.x"]
+        gover:
+          - "1.25.x"
+          - "1.26.x"
     runs-on: ubuntu-24.04
     steps:
       - name: Check out repository

--- a/.github/workflows/validate-action-pinning.yml
+++ b/.github/workflows/validate-action-pinning.yml
@@ -1,0 +1,24 @@
+name: Validate GitHub Action pinning
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+  push:
+    branches:
+      - "main"
+    paths:
+      - ".github/workflows/**"
+
+permissions:
+  contents: read
+
+jobs:
+  enforce-pinning:
+    name: Enforce commit SHA pinning
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Ensure SHA-pinned Actions
+        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@70c4af2ed5282c51ba40566d026d6647852ffa3e # v5.0.1

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+SHELL := /bin/bash
+
+.PHONY: fmt lint tool-%
+
+export PATH := $(shell go tool bine path):$(PATH)
+
+# Run only the configured formatters (gofumpt, gci, etc.).
+fmt: FMT_FLAGS ?=
+fmt: tool-golangci-lint
+	golangci-lint fmt $(FMT_FLAGS)
+
+# Run linters and apply any auto-fixable issues, including formatter fixes.
+lint: LINT_FLAGS ?= --fix=1
+lint: tool-golangci-lint
+	golangci-lint run $(LINT_FLAGS)
+
+tool-%:
+	@go tool bine get $* 1> /dev/null

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module go.artefactual.dev/tools
 
-go 1.24.0
+go 1.25
+
+toolchain go1.26.1
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.36.3


### PR DESCRIPTION
Looks like you can define `go 1.25` for min. lang requirement (as opposed to `go 1.25.0`) as long as you also include the preferred version of the toolchain for local development.