### PR TITLE
Allow Azure auth overrides for azblob buckets

### DIFF
--- a/bucket/bucket.go
+++ b/bucket/bucket.go
@@ -8,12 +8,15 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"gocloud.dev/blob"
-	_ "gocloud.dev/blob/azureblob"
+	"gocloud.dev/blob/azureblob"
 	"gocloud.dev/blob/s3blob"
 )
 
@@ -34,11 +37,35 @@ type Config struct {
 	Profile   string
 	Region    string
 	PathStyle bool
+
+	// Azure configures authentication for azblob URLs when callers need to
+	// provide credentials programmatically instead of relying on environment
+	// variables or the default Go CDK opener.
+	Azure *AzureConfig
+}
+
+type AzureConfig struct {
+	// StorageAccount identifies the Azure Blob Storage account to connect to.
+	// It is required for shared key auth and optional for other auth modes,
+	// where the account can also come from the URL or environment.
+	StorageAccount string
+
+	// StorageKey enables shared key authentication.
+	StorageKey string
+
+	// TenantID, ClientID, and ClientSecret enable Azure AD client secret
+	// authentication when all are set. If neither shared key nor a complete
+	// client secret tuple is provided, the default Azure credential chain is
+	// used.
+	TenantID     string
+	ClientID     string
+	ClientSecret string
 }
 
 // NewWithConfig opens a bucket based on the provided configuration. It defaults
 // to using AWS SDK v2 via s3blob.OpenBucketV2 unless the URL field is
-// specified, in which case it uses blob.OpenBucket.
+// specified. URL based configs are opened via blob.OpenBucket, except azblob
+// URLs with Azure config overrides, which use a custom Azure URL opener.
 func NewWithConfig(ctx context.Context, c *Config) (*blob.Bucket, error) {
 	if c == nil {
 		return nil, errors.New("config is undefined")
@@ -49,13 +76,84 @@ func NewWithConfig(ctx context.Context, c *Config) (*blob.Bucket, error) {
 		err error
 	)
 
-	if c.URL != "" {
+	if isAzureBucketURL(c.URL) && c.Azure != nil {
+		b, err = openAzureWithOverrides(ctx, c.URL, c.Azure)
+	} else if c.URL != "" {
 		b, err = openWithURL(ctx, c.URL)
 	} else {
 		b, err = openWithConfig(ctx, c)
 	}
 
 	return b, err
+}
+
+func isAzureBucketURL(bucketURL string) bool {
+	u, err := url.Parse(bucketURL)
+	return err == nil && u.Scheme == azureblob.Scheme
+}
+
+// openAzureWithOverrides returns a bucket with a custom opener for azblob URLs
+// when Azure config overrides are provided. Client secret auth takes precedence
+// over shared key auth when both are configured. Partial shared key or client
+// secret configs are rejected; all other cases fall back to Azure's default
+// credential chain.
+func openAzureWithOverrides(ctx context.Context, u string, c *AzureConfig) (*blob.Bucket, error) {
+	if c == nil {
+		return nil, fmt.Errorf("open Azure bucket from URL %q with overrides: config is undefined", u)
+	}
+
+	makeClient := azureblob.NewDefaultClient
+	if c.TenantID != "" || c.ClientID != "" || c.ClientSecret != "" {
+		if c.TenantID == "" || c.ClientID == "" || c.ClientSecret == "" {
+			return nil, fmt.Errorf(
+				"open Azure bucket from URL %q with overrides: "+
+					"client secret auth requires tenant ID, client ID, and client secret",
+				u,
+			)
+		}
+		makeClient = func(u azureblob.ServiceURL, n azureblob.ContainerName) (*container.Client, error) {
+			containerURL, err := url.JoinPath(string(u), string(n))
+			if err != nil {
+				return nil, err
+			}
+			cred, err := azidentity.NewClientSecretCredential(c.TenantID, c.ClientID, c.ClientSecret, nil)
+			if err != nil {
+				return nil, err
+			}
+			return container.NewClient(containerURL, cred, nil)
+		}
+	} else if c.StorageKey != "" {
+		if c.StorageAccount == "" {
+			return nil, fmt.Errorf(
+				"open Azure bucket from URL %q with overrides: "+
+					"shared key auth requires storage account and storage key",
+				u,
+			)
+		}
+		makeClient = func(u azureblob.ServiceURL, n azureblob.ContainerName) (*container.Client, error) {
+			containerURL, err := url.JoinPath(string(u), string(n))
+			if err != nil {
+				return nil, err
+			}
+			cred, err := azblob.NewSharedKeyCredential(c.StorageAccount, c.StorageKey)
+			if err != nil {
+				return nil, err
+			}
+			return container.NewClientWithSharedKeyCredential(containerURL, cred, nil)
+		}
+	}
+
+	urlMux := new(blob.URLMux)
+	urlMux.RegisterBucket(azureblob.Scheme, &azureblob.URLOpener{
+		MakeClient:        makeClient,
+		ServiceURLOptions: azureblob.ServiceURLOptions{AccountName: c.StorageAccount},
+	})
+	b, err := urlMux.OpenBucket(ctx, u)
+	if err != nil {
+		return nil, fmt.Errorf("open Azure bucket from URL %q with overrides: %v", u, err)
+	}
+
+	return b, nil
 }
 
 func openWithURL(ctx context.Context, url string) (*blob.Bucket, error) {

--- a/bucket/bucket_test.go
+++ b/bucket/bucket_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	s3v2 "github.com/aws/aws-sdk-go-v2/service/s3"
 	"gocloud.dev/blob"
@@ -97,6 +98,121 @@ func TestNewWithConfig(t *testing.T) {
 				SecretKey: "secret",
 			},
 			errMsg: "open bucket: s3blob.OpenBucket: bucketName is required",
+		},
+		"Opens Azure URL with shared key auth": {
+			config: &bucket.Config{
+				URL: "azblob://name",
+				Azure: &bucket.AzureConfig{
+					StorageAccount: "account",
+					StorageKey:     "dGVzdA==",
+				},
+			},
+			require: func(b *blob.Bucket) {
+				var client *container.Client
+				assert.Equal(t, b.As(&client), true)
+				assert.Equal(t, client.URL(), "https://account.blob.core.windows.net/name")
+			},
+		},
+		"Opens Azure URL with client secret auth": {
+			config: &bucket.Config{
+				URL: "azblob://name",
+				Azure: &bucket.AzureConfig{
+					StorageAccount: "account",
+					TenantID:       "tenant",
+					ClientID:       "client",
+					ClientSecret:   "secret",
+				},
+			},
+			require: func(b *blob.Bucket) {
+				var client *container.Client
+				assert.Equal(t, b.As(&client), true)
+				assert.Equal(t, client.URL(), "https://account.blob.core.windows.net/name")
+			},
+		},
+		"Opens Azure URL with client secret auth without storage account": {
+			config: &bucket.Config{
+				URL: "azblob://name?storage_account=account",
+				Azure: &bucket.AzureConfig{
+					TenantID:     "tenant",
+					ClientID:     "client",
+					ClientSecret: "secret",
+				},
+			},
+			require: func(b *blob.Bucket) {
+				var client *container.Client
+				assert.Equal(t, b.As(&client), true)
+				assert.Equal(t, client.URL(), "https://account.blob.core.windows.net/name")
+			},
+		},
+		"Opens Azure URL with default auth": {
+			config: &bucket.Config{
+				URL: "azblob://name",
+				Azure: &bucket.AzureConfig{
+					StorageAccount: "account",
+				},
+			},
+			require: func(b *blob.Bucket) {
+				var client *container.Client
+				assert.Equal(t, b.As(&client), true)
+				assert.Equal(t, client.URL(), "https://account.blob.core.windows.net/name")
+			},
+		},
+		"Opens Azure URL with default opener when Azure config is empty": {
+			config: &bucket.Config{
+				URL: "azblob://name?storage_account=account",
+			},
+			require: func(b *blob.Bucket) {
+				var client *container.Client
+				assert.Equal(t, b.As(&client), true)
+				assert.Equal(t, client.URL(), "https://account.blob.core.windows.net/name")
+			},
+		},
+		"Opens Azure URL with empty Azure config": {
+			config: &bucket.Config{
+				URL:   "azblob://name?storage_account=account",
+				Azure: &bucket.AzureConfig{},
+			},
+			require: func(b *blob.Bucket) {
+				var client *container.Client
+				assert.Equal(t, b.As(&client), true)
+				assert.Equal(t, client.URL(), "https://account.blob.core.windows.net/name")
+			},
+		},
+		"Prefers Azure client secret when multiple auth methods are provided": {
+			config: &bucket.Config{
+				URL: "azblob://name",
+				Azure: &bucket.AzureConfig{
+					StorageAccount: "account",
+					StorageKey:     "key", // Would fail if used as it is not base64 encoded
+					TenantID:       "tenant",
+					ClientID:       "client",
+					ClientSecret:   "secret",
+				},
+			},
+			require: func(b *blob.Bucket) {
+				var client *container.Client
+				assert.Equal(t, b.As(&client), true)
+				assert.Equal(t, client.URL(), "https://account.blob.core.windows.net/name")
+			},
+		},
+		"Rejects partial Azure shared key auth": {
+			config: &bucket.Config{
+				URL: "azblob://name",
+				Azure: &bucket.AzureConfig{
+					StorageKey: "dGVzdA==",
+				},
+			},
+			errMsg: `open Azure bucket from URL "azblob://name" with overrides: shared key auth requires storage account and storage key`,
+		},
+		"Rejects partial Azure client secret auth": {
+			config: &bucket.Config{
+				URL: "azblob://name",
+				Azure: &bucket.AzureConfig{
+					StorageAccount: "account",
+					ClientID:       "client",
+				},
+			},
+			errMsg: `open Azure bucket from URL "azblob://name" with overrides: client secret auth requires tenant ID, client ID, and client secret`,
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ go 1.25
 toolchain go1.26.2
 
 require (
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
+	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.3
 	github.com/aws/aws-sdk-go-v2 v1.40.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.2
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.2
@@ -14,6 +16,7 @@ require (
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/go-cmp v0.7.0
 	github.com/gorilla/mux v1.8.1
+	github.com/otiai10/copy v1.14.0
 	go.temporal.io/api v1.29.2
 	go.temporal.io/sdk v1.26.0
 	go.uber.org/mock v0.4.0
@@ -29,9 +32,7 @@ require (
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.3 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest/to v0.4.1 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect
@@ -85,7 +86,6 @@ require (
 	github.com/mholt/archives v0.1.1 // indirect
 	github.com/minio/minlz v1.0.0 // indirect
 	github.com/nwaples/rardecode/v2 v2.1.0 // indirect
-	github.com/otiai10/copy v1.14.0
 	github.com/pborman/uuid v1.2.1 // indirect
 	github.com/peterbourgon/ff/v4 v4.0.0-alpha.4 // indirect
 	github.com/pierrec/lz4/v4 v4.1.21 // indirect


### PR DESCRIPTION
Support Azure specific auth configuration in bucket.Config while keeping NewWithConfig unchanged. For azblob:// URLs, the bucket package now uses a custom Azure URL opener that supports shared key auth, client secret auth, and default Azure credentials, with client secret auth taking precedence when both methods are configured.

---

A bit of background:

- Azure URL support was added in this project here: https://github.com/artefactual-labs/gotools/pull/26.
- For security reasons, a client preferred encrypted config files to environment variables. So the configuration option was added in Enduro here: https://github.com/artefactual-sdps/enduro/pull/1248.
- Santi then asked to use AD credentials for auth and was forced to set up an storage key in Azure. This implementation will allow both client secret and shared key auth.
- Enduro's initial implementation only allowed to configure the ingest storage bucket this way, moving it here with the shared package and config makes it easier to add Azure support to other configurable buckets in Enduro. See https://github.com/artefactual-sdps/enduro/issues/1382.