### PR TITLE
Preserve default S3 endpoint resolution

### DIFF
--- a/bucket/bucket.go
+++ b/bucket/bucket.go
@@ -67,13 +67,6 @@ func openWithURL(ctx context.Context, url string) (*blob.Bucket, error) {
 }
 
 func openWithConfig(ctx context.Context, c *Config) (*blob.Bucket, error) {
-	addr := c.Endpoint
-	if u, err := url.Parse(c.Endpoint); err == nil {
-		if !strings.HasPrefix(u.Scheme, "http") {
-			addr = "http://" + addr
-		}
-	}
-
 	awscfg, err := config.LoadDefaultConfig(
 		ctx,
 		config.WithSharedConfigProfile(c.Profile),
@@ -83,13 +76,6 @@ func openWithConfig(ctx context.Context, c *Config) (*blob.Bucket, error) {
 				c.AccessKey, c.SecretKey, c.Token,
 			),
 		),
-		config.WithEndpointResolverWithOptions(
-			aws.EndpointResolverWithOptionsFunc(
-				func(service, region string, options ...any) (aws.Endpoint, error) {
-					return aws.Endpoint{URL: addr}, nil
-				},
-			),
-		),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("load AWS default config: %v", err)
@@ -97,6 +83,11 @@ func openWithConfig(ctx context.Context, c *Config) (*blob.Bucket, error) {
 
 	client := s3.NewFromConfig(awscfg, func(opts *s3.Options) {
 		opts.UsePathStyle = c.PathStyle
+		if c.Endpoint != "" {
+			// BaseEndpoint customizes only this S3 client. Leaving it unset lets
+			// the AWS SDK use its normal endpoint resolution for AWS S3.
+			opts.BaseEndpoint = aws.String(normalizeEndpoint(c.Endpoint))
+		}
 	})
 	b, err := s3blob.OpenBucketV2(ctx, client, c.Bucket, nil)
 	if err != nil {
@@ -104,4 +95,13 @@ func openWithConfig(ctx context.Context, c *Config) (*blob.Bucket, error) {
 	}
 
 	return b, nil
+}
+
+func normalizeEndpoint(endpoint string) string {
+	if u, err := url.Parse(endpoint); err == nil {
+		if !strings.HasPrefix(u.Scheme, "http") {
+			return "http://" + endpoint
+		}
+	}
+	return endpoint
 }

--- a/bucket/bucket_test.go
+++ b/bucket/bucket_test.go
@@ -2,8 +2,10 @@ package bucket_test
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	s3v2 "github.com/aws/aws-sdk-go-v2/service/s3"
 	"gocloud.dev/blob"
 	_ "gocloud.dev/blob/fileblob"
@@ -43,6 +45,8 @@ func TestNewWithConfig(t *testing.T) {
 				opts := client.Options()
 				assert.Equal(t, opts.Region, "region")
 				assert.Equal(t, opts.UsePathStyle, true)
+				assert.Equal(t, aws.ToString(opts.BaseEndpoint), "http://foobar:12345")
+				assert.Assert(t, opts.EndpointResolver == nil)
 
 				_, err := client.ListBuckets(context.Background(), &s3v2.ListBucketsInput{})
 				assert.ErrorContains(t, err, "http://foobar:12345/?x-id=ListBuckets")
@@ -59,6 +63,10 @@ func TestNewWithConfig(t *testing.T) {
 			require: func(b *blob.Bucket) {
 				var client *s3v2.Client
 				assert.Equal(t, b.As(&client), true)
+
+				opts := client.Options()
+				assert.Equal(t, aws.ToString(opts.BaseEndpoint), "http://foobar:12345")
+				assert.Assert(t, opts.EndpointResolver == nil)
 
 				_, err := client.ListBuckets(context.Background(), &s3v2.ListBucketsInput{})
 				assert.ErrorContains(t, err, "http://foobar:12345/?x-id=ListBuckets")
@@ -113,4 +121,28 @@ func TestNewWithConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewWithConfigWithoutEndpointUsesDefaultS3Resolution(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("AWS_ENDPOINT_URL", "")
+	t.Setenv("AWS_ENDPOINT_URL_S3", "")
+	t.Setenv("AWS_CONFIG_FILE", filepath.Join(tempDir, "config"))
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.Join(tempDir, "credentials"))
+
+	b, err := bucket.NewWithConfig(context.Background(), &bucket.Config{
+		Bucket:    "name",
+		Region:    "region",
+		AccessKey: "access",
+		SecretKey: "secret",
+	})
+	assert.NilError(t, err)
+	defer b.Close()
+
+	var client *s3v2.Client
+	assert.Equal(t, b.As(&client), true)
+
+	opts := client.Options()
+	assert.Assert(t, opts.BaseEndpoint == nil)
+	assert.Assert(t, opts.EndpointResolver == nil)
 }


### PR DESCRIPTION
Only set a custom S3 endpoint when Config.Endpoint is explicitly configured.

Use the S3 client BaseEndpoint option for explicit endpoints instead of the deprecated global endpoint resolver, so empty endpoints keep the AWS SDK's default resolution behavior.

Fixes https://github.com/artefactual-labs/gotools/issues/36.